### PR TITLE
OAuth2 proof of concept server.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ dependencies = [
  "blocking",
  "futures-lite",
  "once_cell",
+ "tokio",
 ]
 
 [[package]]
@@ -415,6 +416,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,12 +524,15 @@ dependencies = [
  "instant",
  "itertools",
  "log",
+ "oauth2",
  "rand 0.8.5",
+ "reqwest",
  "scopeguard",
  "serde",
  "serde_json",
  "sqlx",
  "tide",
+ "tide-jsx",
  "time 0.3.17",
  "tungstenite",
  "url",
@@ -745,6 +755,16 @@ dependencies = [
  "sha2 0.9.9",
  "time 0.2.27",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1056,6 +1076,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "enum-map"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1207,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,9 +1330,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite 0.2.9",
  "pin-utils",
  "slab",
@@ -1370,6 +1416,25 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1488,6 +1553,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite 0.2.9",
+]
+
+[[package]]
 name = "http-client"
 version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1605,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
 name = "humansize"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +1621,56 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite 0.2.9",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1618,6 +1750,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
@@ -1782,6 +1920,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,6 +1967,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "oauth2"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaf26a72311c087f8c5ba617c96fac67a5c04f430e716ac8d8ab2de62e23368"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "getrandom 0.2.8",
+ "http",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.6",
+ "thiserror",
+ "url",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,6 +2007,51 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -2156,6 +2387,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+dependencies = [
+ "base64 0.21.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite 0.2.9",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,6 +2515,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,6 +2549,29 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645926f31b250a2dca3c232496c2d898d91036e45ca0e97e0e2390c54e11be36"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2312,6 +2626,15 @@ checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b04f22b563c91331a10074bda3dd5492e3cc39d56bd557e91c0af42b6c7341"
+dependencies = [
  "serde",
 ]
 
@@ -2741,6 +3064,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2916,6 +3253,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tokio"
+version = "1.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "pin-project-lite 0.2.9",
+ "socket2",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite 0.2.9",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,6 +3312,38 @@ checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite 0.2.9",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
@@ -3071,6 +3492,16 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -3318,3 +3749,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "arrayref"
@@ -363,6 +363,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-tungstenite"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6acf7e4a267eecbb127ed696bb2d50572c22ba7f586a646321e1798d8336a1"
+dependencies = [
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project-lite 0.2.9",
+ "tungstenite",
+]
+
+[[package]]
 name = "atoi"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,13 +501,19 @@ dependencies = [
 name = "bughouse_console"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-std",
+ "async-tungstenite",
  "bughouse_chess",
  "clap",
  "console",
  "crossterm",
  "enum-map",
  "env_logger",
+ "futures-io",
+ "futures-util",
+ "http",
+ "http-types",
  "instant",
  "itertools",
  "log",
@@ -503,6 +522,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tide",
  "time 0.3.17",
  "tungstenite",
  "url",
@@ -1491,6 +1511,7 @@ dependencies = [
  "base64 0.13.1",
  "cookie",
  "futures-lite",
+ "http",
  "infer",
  "pin-project-lite 0.2.9",
  "rand 0.7.3",

--- a/bughouse_console/Cargo.toml
+++ b/bughouse_console/Cargo.toml
@@ -5,12 +5,18 @@ authors = ["Andrei Matveiakin <a.matveiakin@gmail.com>"]
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.68"
 async-std = "1.6.5"
+async-tungstenite = "0.19.0"
 crossterm = "0.25.0"
 console = "0.15.2"
 clap = { version = "4.0.29", features = ["cargo"] }
 enum-map = "2.4.1"
 env_logger = "0.10.0"
+futures-io = "0.3.25"
+futures-util = "0.3.25"
+http = "0.2.8"
+http-types = { version = "2.12.0", features = ["hyperium_http"] }
 instant = "0.1.12"
 itertools = "0.10.5"
 log = "0.4.17"
@@ -21,6 +27,7 @@ url = "2.3.1"
 serde = "1.0.149"
 serde_json = "1.0.89"
 sqlx = { version = "0.6.2", features = ["postgres", "sqlite", "runtime-async-std-rustls", "time"] }
+tide = "0.16.0"
 time = "0.3.17"
 uuid = { version = "1.2.2", features = ["v4"] }
 

--- a/bughouse_console/Cargo.toml
+++ b/bughouse_console/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.68"
-async-std = "1.6.5"
+async-std = { version = "1.6.5", features = ["tokio1"] }
 async-tungstenite = "0.19.0"
 crossterm = "0.25.0"
 console = "0.15.2"
@@ -32,3 +32,6 @@ time = "0.3.17"
 uuid = { version = "1.2.2", features = ["v4"] }
 
 bughouse_chess = { path = ".." }
+oauth2 = "4.3.0"
+reqwest = { version = "0.11.14", features = ["json"] }
+tide-jsx = "0.4.0"

--- a/bughouse_console/src/async_server_main.rs
+++ b/bughouse_console/src/async_server_main.rs
@@ -1,0 +1,181 @@
+// Improvement potential. Try to do everything via message-passing, without `Mutex`es,
+//   but also witout threading and network logic inside `ServerState`.
+//   Problem. Adding client via event is a potential race condition in case the
+//   first TCP message from the client arrives earlier.
+
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use async_tungstenite::WebSocketStream;
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::{sink::SinkExt, stream::StreamExt};
+use log::{error, info, warn};
+use tungstenite::protocol;
+
+use bughouse_chess::server::*;
+use bughouse_chess::server_hooks::ServerHooks;
+use bughouse_chess::*;
+
+use crate::network::{self, CommunicationError};
+use crate::server_main::{ServerConfig, DatabaseOptions};
+use crate::sqlx_server_hooks::*;
+
+fn to_debug_string<T: std::fmt::Debug>(v: T) -> String {
+    format!("{v:?}")
+}
+
+async fn handle_connection<S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static>(
+    peer_addr: String,
+    mut stream: WebSocketStream<S>,
+    tx: mpsc::SyncSender<IncomingEvent>,
+    clients: Arc<Mutex<Clients>>,
+) -> tide::Result<()> {
+    let (mut stream_tx, mut stream_rx) = stream.split();
+    info!("Client connected: {}", peer_addr);
+
+    let (client_tx, client_rx) = mpsc::channel();
+    let client_id = clients
+        .lock()
+        .unwrap()
+        .add_client(client_tx, peer_addr.to_string());
+    let clients_remover1 = Arc::clone(&clients);
+    let clients_remover2 = Arc::clone(&clients);
+    async_std::task::spawn(async move {
+        loop {
+            match network::read_obj_async(&mut stream_rx).await {
+                Ok(ev) => {
+                    tx.send(IncomingEvent::Network(client_id, ev)).unwrap();
+                }
+                Err(err) => {
+                    if let Some(logging_id) =
+                        clients_remover1.lock().unwrap().remove_client(client_id)
+                    {
+                        match err {
+                            CommunicationError::ConnectionClosed => {
+                                info!("Client {} disconnected", logging_id)
+                            }
+                            err => warn!(
+                                "Client {} disconnected due to read error: {:?}",
+                                logging_id, err
+                            ),
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    });
+
+    // Still spawning an OS thread here because client_rx is a
+    // synchronous receiver.
+    // Calling blocking functions (such as client_tx.recv()) within async context
+    // means completely blocking an executor thread, which quickly leads to
+    // stavation and deadlocks because the number of async executor threads
+    // is limited.
+    let (done_tx, done_rx) = async_std::channel::bounded(1);
+    std::thread::spawn(move || {
+        loop {
+            let Ok(ev) = client_rx.recv() else { break };
+            match async_std::task::block_on(network::write_obj_async(&mut stream_tx, &ev)) {
+                Ok(()) => {}
+                Err(err) => {
+                    if let Some(logging_id) =
+                        clients_remover2.lock().unwrap().remove_client(client_id)
+                    {
+                        warn!(
+                            "Client {} disconnected due to write error: {:?}",
+                            logging_id, err
+                        );
+                    }
+                    break;
+                }
+            }
+        }
+        async_std::task::block_on(done_tx.send(()));
+    });
+    // This instead of just running the loop to completion or join() on the
+    // thread for the same reason of not blocking the async executor thread.
+    done_rx.recv().await.unwrap();
+    Ok(())
+}
+
+pub fn run(config: ServerConfig) {
+    let (tx, rx) = mpsc::sync_channel(1000);
+    let tx_tick = tx.clone();
+    thread::spawn(move || loop {
+        thread::sleep(Duration::from_millis(100));
+        tx_tick.send(IncomingEvent::Tick).unwrap();
+    });
+    let clients = Arc::new(Mutex::new(Clients::new()));
+    let clients_copy = Arc::clone(&clients);
+
+    thread::spawn(move || {
+        let hooks = match config.database_options {
+            DatabaseOptions::NoDatabase => None,
+            DatabaseOptions::Sqlite(address) => Some(Box::new(
+                SqlxServerHooks::<sqlx::Sqlite>::new(address.as_str())
+                    .unwrap_or_else(|err| panic!("Cannot connect to SQLite DB {address}:\n{err}")),
+            ) as Box<dyn ServerHooks>),
+            DatabaseOptions::Postgres(address) => Some(Box::new(
+                SqlxServerHooks::<sqlx::Postgres>::new(address.as_str()).unwrap_or_else(|err| {
+                    panic!("Cannot connect to Postgres DB {address}:\n{err}")
+                }),
+            ) as Box<dyn ServerHooks>),
+        };
+        let mut server_state = ServerState::new(clients_copy, hooks);
+
+        for event in rx {
+            server_state.apply_event(event);
+        }
+        panic!("Unexpected end of events stream");
+    });
+
+    let mut app = tide::new();
+    app.at("/").get(move |req: tide::Request<()>| {
+        let mytx = tx.clone();
+        let myclients = clients.clone();
+        async move {
+            let peer_addr = req.peer_addr().map_or_else(
+                || {
+                    Err(tide::Error::new(
+                        403,
+                        anyhow::Error::msg("Peer address missing"),
+                    ))
+                },
+                |x| Ok(x.to_owned()),
+            )?;
+            // tide::Request -> http_types::Request -> http::Request<Body> -> http::Request<()>.
+            let http_types_req: http_types::Request = req.into();
+            let http_req_with_body: http::Request<http_types::Body> = http_types_req.into();
+            let http_req = http_req_with_body.map(|_| ());
+
+            let http_resp = tungstenite::handshake::server::create_response(&http_req)
+                .map_err(|e| tide::Error::new(400, e))?;
+
+            // And the reverse chain
+            let http_resp_with_body = http_resp.map(|_| http_types::Body::empty());
+            let mut http_types_resp: http_types::Response = http_resp_with_body.into();
+
+            let upgrade_receiver = http_types_resp.recv_upgrade().await;
+
+            async_std::task::spawn(async move {
+                if let Some(stream) = upgrade_receiver.await {
+                    let stream =
+                        WebSocketStream::from_raw_socket(stream, protocol::Role::Server, None)
+                            .await;
+                    if let Err(err) =
+                        handle_connection(peer_addr, stream, mytx, myclients).await
+                    {
+                        error!("{}", err);
+                    }
+                } else {
+                    warn!("never received an upgrade!");
+                }
+            });
+            Ok(http_types_resp)
+        }
+    });
+    async_std::task::block_on(async { app.listen(format!("0.0.0.0:{}", network::PORT)).await })
+        .expect("Failed to start the app");
+}

--- a/bughouse_console/src/async_server_main.rs
+++ b/bughouse_console/src/async_server_main.rs
@@ -133,11 +133,11 @@ async fn handle_connection<S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'st
 }
 
 pub fn run(config: ServerConfig) {
-    if config.auth_options != AuthOptions::NoAuth
-        && config.session_options == SessionOptions::NoSessions
-    {
-        panic!("Authentication is enabled while sessions are not.");
-    }
+    assert!(
+        config.auth_options == AuthOptions::NoAuth
+            || config.session_options != SessionOptions::NoSessions,
+        "Authentication is enabled while sessions are not."
+    );
 
     // Limited buffer for data streaming from clients into the server.
     // When this is full because ServerState::apply_event isn't coping with

--- a/bughouse_console/src/auth.rs
+++ b/bughouse_console/src/auth.rs
@@ -42,7 +42,10 @@ pub struct NewSessionQuery {
 
 impl NewSessionQuery {
     pub fn parse(self) -> (AuthorizationCode, CsrfToken) {
-        (AuthorizationCode::new(self.code), CsrfToken::new(self.state))
+        (
+            AuthorizationCode::new(self.code),
+            CsrfToken::new(self.state),
+        )
     }
 }
 

--- a/bughouse_console/src/auth.rs
+++ b/bughouse_console/src/auth.rs
@@ -1,0 +1,104 @@
+use anyhow::Context;
+use oauth2::{basic::BasicClient, revocation::StandardRevocableToken, TokenResponse};
+// Alternatively, this can be oauth2::curl::http_client or a custom.
+use oauth2::reqwest::async_http_client;
+use oauth2::{
+    url, AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, PkceCodeChallenge,
+    RedirectUrl, RevocationUrl, Scope, TokenUrl,
+};
+use serde::Deserialize;
+use std::env;
+use url::Url;
+
+use crate::session::UserInfo;
+
+pub struct Config {
+    // The URL where oauth proviver will redirect, passing the auth code
+    // as a parameter.
+    pub callback_url: String,
+}
+
+#[derive(Clone)]
+pub struct GoogleAuth {
+    client: BasicClient,
+}
+
+// Internal Google-specific user info struct, used for
+// deserializing user info JSON responses from the API.
+// https://cloud.google.com/identity-platform/docs/reference/rest/v1/UserInfo
+#[derive(Deserialize)]
+struct GoogleUserInfo {
+    email: String,
+    name: Option<String>,
+}
+
+// Internal OAuth-specific (Google-specific?) structure of the redirected
+// URL parameters.
+#[derive(Deserialize)]
+pub struct NewSessionQuery {
+    code: String,
+    state: String,
+}
+
+impl NewSessionQuery {
+    pub fn parse(self) -> (AuthorizationCode, CsrfToken) {
+        (AuthorizationCode::new(self.code), CsrfToken::new(self.state))
+    }
+}
+
+impl GoogleAuth {
+    pub fn new(config: Config) -> anyhow::Result<Self> {
+        // See https://accounts.google.com/.well-known/openid-configuration
+        let google_client_id = ClientId::new(
+            env::var("GOOGLE_CLIENT_ID")
+                .context("Missing the GOOGLE_CLIENT_ID environment variable.")?,
+        );
+        let google_client_secret = ClientSecret::new(
+            env::var("GOOGLE_CLIENT_SECRET")
+                .context("Missing the GOOGLE_CLIENT_SECRET environment variable.")?,
+        );
+        let auth_url = AuthUrl::new("https://accounts.google.com/o/oauth2/v2/auth".to_owned())
+            .context("Invalid authorization endpoint URL")?;
+        let token_url = TokenUrl::new("https://oauth2.googleapis.com/token".to_owned())
+            .context("Invalid token endpoint URL")?;
+        let client = BasicClient::new(
+            google_client_id,
+            Some(google_client_secret),
+            auth_url,
+            Some(token_url),
+        )
+        .set_revocation_uri(
+            RevocationUrl::new("https://oauth2.googleapis.com/revoke".to_owned())
+                .context("Invalid revocation endpoint URL")?,
+        )
+        .set_redirect_uri(RedirectUrl::new(config.callback_url).context("Invalid redirect URL")?);
+        Ok(Self { client })
+    }
+
+    pub fn start(&self) -> anyhow::Result<(Url, CsrfToken)> {
+        Ok(self
+            .client
+            .authorize_url(CsrfToken::new_random)
+            .add_scope(Scope::new("openid profile email".to_owned()))
+            .url())
+    }
+
+    pub async fn user_info(&self, code: AuthorizationCode) -> anyhow::Result<UserInfo> {
+        let token_response = self
+            .client
+            .exchange_code(code)
+            .request_async(async_http_client)
+            .await?;
+        let response = reqwest::get(format!(
+            "https://www.googleapis.com/oauth2/v1/userinfo?access_token={}",
+            token_response.access_token().secret()
+        ))
+        .await?
+        .json::<GoogleUserInfo>()
+        .await?;
+        Ok(UserInfo {
+            email: Some(response.email),
+            name: response.name,
+        })
+    }
+}

--- a/bughouse_console/src/main.rs
+++ b/bughouse_console/src/main.rs
@@ -63,7 +63,8 @@ fn main() -> io::Result<()> {
                 .arg(arg!(--"sqlite-db" [DB] "Path to an sqlite database file"))
                 .arg(arg!(--"postgres-db" [DB] "Address of a postgres database"))
                 .arg(arg!(--"auth" [AUTH_OPTION] "Either NoAuth or Google. The latter enables authentication using Google OAuth2. Reads GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET env variables"))
-                .arg(arg!(--"auth-callback-is-https" "Whether to upgrade the auth callback address to https"))
+                .arg(arg!(--"auth-callback-is-https" "Upgrade the auth callback address to https. This can be useful when the server is behind a https proxy such as Apache."))
+                .arg(arg!(--"enable-sessions" "Whether to enable the tide session middleware."))
         )
         .subcommand(
             Command::new("client")
@@ -97,10 +98,15 @@ fn main() -> io::Result<()> {
                 },
                 Some(a) => panic!("Unrecognized auth option {a}"),
             };
+            let session_options = if sub_matches.get_flag("enable-sessions") {
+                crate::server_main::SessionOptions::WithNewRandomSecret
+            } else {
+                crate::server_main::SessionOptions::NoSessions
+            };
             async_server_main::run(server_main::ServerConfig {
                 database_options: database_options_from_args(sub_matches),
                 auth_options,
-                session_options: server_main::SessionOptions::WithNewRandomSecret,
+                session_options,
             });
             Ok(())
         }

--- a/bughouse_console/src/main.rs
+++ b/bughouse_console/src/main.rs
@@ -24,10 +24,12 @@ extern crate bughouse_chess;
 pub mod network;
 pub mod tui;
 
+mod auth;
 mod async_server_main;
 mod client_main;
 mod sqlx_server_hooks;
 mod server_main;
+mod session;
 mod stress_test;
 
 use std::io;

--- a/bughouse_console/src/network.rs
+++ b/bughouse_console/src/network.rs
@@ -4,8 +4,6 @@
 use std::io;
 use std::net::TcpStream;
 
-use async_tungstenite::WebSocketStream;
-use futures_io::{AsyncRead, AsyncWrite};
 use futures_util::{sink::SinkExt, stream::StreamExt};
 use serde::{de, Serialize};
 use tungstenite::{protocol::Role, Message, WebSocket};
@@ -54,7 +52,7 @@ where
 pub async fn write_obj_async<T, S>(socket: &mut S, obj: &T) -> Result<(), CommunicationError>
 where
     T: Serialize,
-    S: SinkExt<Message, Error=tungstenite::Error> + Unpin,
+    S: SinkExt<Message, Error = tungstenite::Error> + Unpin,
 {
     let serialized = serde_json::to_string(obj).map_err(|err| CommunicationError::Serde(err))?;
     socket

--- a/bughouse_console/src/network.rs
+++ b/bughouse_console/src/network.rs
@@ -4,12 +4,13 @@
 use std::io;
 use std::net::TcpStream;
 
+use async_tungstenite::WebSocketStream;
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::{sink::SinkExt, stream::StreamExt};
 use serde::{de, Serialize};
-use tungstenite::{WebSocket, Message, protocol::Role};
-
+use tungstenite::{protocol::Role, Message, WebSocket};
 
 pub const PORT: u16 = 14361;
-
 
 #[derive(Debug)]
 pub enum CommunicationError {
@@ -25,7 +26,9 @@ where
     S: io::Read + io::Write,
 {
     let serialized = serde_json::to_string(obj).map_err(|err| CommunicationError::Serde(err))?;
-    socket.write_message(Message::Text(serialized)).map_err(|err| CommunicationError::Socket(err))
+    socket
+        .write_message(Message::Text(serialized))
+        .map_err(|err| CommunicationError::Socket(err))
 }
 
 pub fn read_obj<T, S>(socket: &mut WebSocket<S>) -> Result<T, CommunicationError>
@@ -33,14 +36,55 @@ where
     T: de::DeserializeOwned,
     S: io::Read + io::Write,
 {
-    let msg = socket.read_message().map_err(|err| CommunicationError::Socket(err))?;
+    let msg = socket
+        .read_message()
+        .map_err(|err| CommunicationError::Socket(err))?;
     match msg {
-        Message::Text(msg) => serde_json::from_str(&msg).map_err(|err| CommunicationError::Serde(err)),
+        Message::Text(msg) => {
+            serde_json::from_str(&msg).map_err(|err| CommunicationError::Serde(err))
+        }
         Message::Close(_) => Err(CommunicationError::ConnectionClosed),
-        _ => Err(CommunicationError::BughouseProtocol(format!("Expected text, got {:?}", msg))),
+        _ => Err(CommunicationError::BughouseProtocol(format!(
+            "Expected text, got {:?}",
+            msg
+        ))),
     }
 }
 
+pub async fn write_obj_async<T, S>(socket: &mut S, obj: &T) -> Result<(), CommunicationError>
+where
+    T: Serialize,
+    S: SinkExt<Message, Error=tungstenite::Error> + Unpin,
+{
+    let serialized = serde_json::to_string(obj).map_err(|err| CommunicationError::Serde(err))?;
+    socket
+        .send(Message::Text(serialized))
+        .await
+        .map_err(|err| CommunicationError::Socket(err))
+}
+
+pub async fn read_obj_async<T, S>(socket: &mut S) -> Result<T, CommunicationError>
+where
+    T: de::DeserializeOwned,
+    S: StreamExt<Item = Result<Message, tungstenite::Error>> + Unpin,
+{
+    let msg = socket
+        .next()
+        .await
+        .map_or(Err(CommunicationError::ConnectionClosed), |m| {
+            m.map_err(|e| CommunicationError::Socket(e))
+        })?;
+    match msg {
+        Message::Text(msg) => {
+            serde_json::from_str(&msg).map_err(|err| CommunicationError::Serde(err))
+        }
+        Message::Close(_) => Err(CommunicationError::ConnectionClosed),
+        _ => Err(CommunicationError::BughouseProtocol(format!(
+            "Expected text, got {:?}",
+            msg
+        ))),
+    }
+}
 
 // TODO: Instead of cloning the socket, consider calling TcpStream.set_nonblocking on the
 //   underlying stream and doing read/writes in the same thread.

--- a/bughouse_console/src/server_main.rs
+++ b/bughouse_console/src/server_main.rs
@@ -28,7 +28,7 @@ pub enum DatabaseOptions {
 #[derive(Debug)]
 pub enum AuthOptions {
     NoAuth,
-    GoogleAuthFromEnv { session_handler_url: String },
+    GoogleAuthFromEnv { callback_is_https: bool },
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/bughouse_console/src/server_main.rs
+++ b/bughouse_console/src/server_main.rs
@@ -102,12 +102,10 @@ fn handle_connection(stream: TcpStream, clients: &Arc<Mutex<Clients>>, tx: mpsc:
 }
 
 pub fn run(config: ServerConfig) {
-    if config.auth_options != AuthOptions::NoAuth {
-        panic!("Auth is not supported by this server implementation.");
-    }
-    if config.session_options != SessionOptions::NoSessions {
-        panic!("Sessions are not supported by this server implementation.");
-    }
+    assert_eq!(config.auth_options, AuthOptions::NoAuth,
+        "Auth is not supported by this server implementation.");
+    assert_eq!(config.session_options, SessionOptions::NoSessions,
+        "Sessions are not supported by this server implementation.");
     let (tx, rx) = mpsc::channel();
     let tx_tick = tx.clone();
     thread::spawn(move || {

--- a/bughouse_console/src/server_main.rs
+++ b/bughouse_console/src/server_main.rs
@@ -18,14 +18,35 @@ use bughouse_chess::server_hooks::ServerHooks;
 use crate::network::{self, CommunicationError};
 use crate::sqlx_server_hooks::*;
 
+#[derive(Debug)]
 pub enum DatabaseOptions {
     NoDatabase,
     Sqlite(String),
     Postgres(String),
 }
 
+#[derive(Debug)]
+pub enum AuthOptions {
+    NoAuth,
+    GoogleAuthFromEnv { session_handler_url: String },
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum SessionOptions {
+    NoSessions,
+
+    // Sessions terminate on server termination.
+    WithNewRandomSecret,
+
+    // Allows for sessions that survive server restart.
+    WithSecret(Vec<u8>),
+}
+
+#[derive(Debug)]
 pub struct ServerConfig {
     pub database_options: DatabaseOptions,
+    pub auth_options: AuthOptions,
+    pub session_options: SessionOptions,
 }
 
 fn to_debug_string<T: std::fmt::Debug>(v: T) -> String {

--- a/bughouse_console/src/server_main.rs
+++ b/bughouse_console/src/server_main.rs
@@ -25,7 +25,7 @@ pub enum DatabaseOptions {
     Postgres(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum AuthOptions {
     NoAuth,
     GoogleAuthFromEnv { callback_is_https: bool },
@@ -102,6 +102,12 @@ fn handle_connection(stream: TcpStream, clients: &Arc<Mutex<Clients>>, tx: mpsc:
 }
 
 pub fn run(config: ServerConfig) {
+    if config.auth_options != AuthOptions::NoAuth {
+        panic!("Auth is not supported by this server implementation.");
+    }
+    if config.session_options != SessionOptions::NoSessions {
+        panic!("Sessions are not supported by this server implementation.");
+    }
     let (tx, rx) = mpsc::channel();
     let tx_tick = tx.clone();
     thread::spawn(move || {

--- a/bughouse_console/src/session.rs
+++ b/bughouse_console/src/session.rs
@@ -1,0 +1,22 @@
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UserInfo {
+    pub email: Option<String>,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Session {
+    pub logged_in: bool,
+    pub user_info: UserInfo,
+}
+
+impl Default for Session {
+    fn default() -> Self {
+        Session {
+            logged_in: false,
+            user_info: UserInfo::default(),
+        }
+    }
+}

--- a/bughouse_console/src/session.rs
+++ b/bughouse_console/src/session.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct UserInfo {


### PR DESCRIPTION
- Branched server_main to be compatible with async webservers. Performance & stability testing to be done on that one, hence a separate sub-command to bughouse_console. It should also spawn one less thread per client.
- Google OAuth2 authentication, fetching profile info (e-mail, full name, profile picture, whatever Google wants to disclose based on user consent).
- Cookie-based (unencrypted but signed) sessions that store user data (e-mail and full name, coming from Google) after a successful login.
- No impact on main functionality - integration to be discussed.
- Deployment requires creating an OAuth API keys in Google Cloud Console and passing them in environment variables.