### PR TITLE
Redirect successful login to /

### DIFF
--- a/www/webpack.config.js
+++ b/www/webpack.config.js
@@ -40,5 +40,8 @@ module.exports = {
     proxy: {
       '/dyn': 'http://127.0.0.1:14361',
     },
+    proxy: {
+      '/auth': 'http://127.0.0.1:14361',
+    },
   },
 };


### PR DESCRIPTION
Collateral nitfixes:
  - rust-fmt on async_server_main
  - added a proxy for the auth prefix for local testing