### PR TITLE
Changes that make google auth workflow work.

### DIFF
--- a/bughouse_console/src/auth_handlers_tide.rs
+++ b/bughouse_console/src/auth_handlers_tide.rs
@@ -277,6 +277,7 @@ pub async fn handle_continue_sign_with_google<DB: Send + Sync + 'static>(
     };
 
     let session_id = get_session_id(&req)?;
+    log::info!("Continue sign in, session {:?}", session_id);
     req.state().session_store.lock().unwrap().set(session_id, session);
 
     let mut resp: tide::Response = req.into();
@@ -288,7 +289,6 @@ pub async fn handle_continue_sign_with_google<DB: Send + Sync + 'static>(
 pub async fn handle_finish_signup_with_google<DB: Send + Sync + 'static>(
     mut req: tide::Request<HttpServerState<DB>>,
 ) -> tide::Result {
-    check_google_csrf(&req)?;
     let FinishSignupWithGoogleData{ user_name } = req.body_form().await?;
 
     validate_player_name(&user_name)
@@ -303,6 +303,7 @@ pub async fn handle_finish_signup_with_google<DB: Send + Sync + 'static>(
     };
 
     let session_id = get_session_id(&req)?;
+    log::info!("Finish sign in, session {:?}, user name {:?}", session_id, user_name);
     let email = {
         let session_store = req.state().session_store.lock().unwrap();
         match session_store.get(&session_id) {

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -69,9 +69,6 @@ where
     pub fn unsubscribe(&mut self, id: &K, subscription_id: SubscriptionId) {
         if let Some(e) = self.entries.get_mut(id) {
             e.unsubscribe(subscription_id);
-            if !e.has_subscribers() {
-                self.entries.remove(&id);
-            }
         }
     }
 
@@ -94,9 +91,6 @@ impl<V> Entry<V> {
     fn update(&mut self, value: V) {
         self.value = value;
         self.update_subscribers();
-    }
-    fn has_subscribers(&self) -> bool {
-        !self.subscriber_tx.is_empty()
     }
     fn update_subscribers(&mut self) {
         for subscriber_tx in self.subscriber_tx.values() {

--- a/www/index.js
+++ b/www/index.js
@@ -1166,7 +1166,7 @@ function sign_up_with_google(event) {
 }
 
 function sign_with_google(event) {
-    location.href = '/auth/login';
+    location.href = '/auth/sign-with-google';
 }
 
 async function log_in(event) {


### PR DESCRIPTION
- Removed GC functionality from session_store. It will leak memory but in practice very slowly. We should fix this though.
- Made sure we always unsubscribe from session store when the client is removed.
- Changed redirect handler to 'get' because js redirects using get right now.
- Changed redirect address to the correct /auth/sign-with-google
- Removed checking csrf token on finish_sign_with_google because at that point we're done with Google.

I'm not suggesting committing this, just documenting what's needed to make OAuth work.