### PR TITLE
Add configuration files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
+ "serde_yaml",
  "skillratings",
  "sqlx",
  "tide",
@@ -2770,6 +2771,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3501,6 +3515,12 @@ dependencies = [
  "generic-array",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "untrusted"

--- a/bughouse_console/Cargo.toml
+++ b/bughouse_console/Cargo.toml
@@ -31,6 +31,7 @@ reqwest = { version = "0.11.14", features = ["json"] }
 scopeguard = "1.1.0"
 serde = "1.0.149"
 serde_json = "1.0.89"
+serde_yaml = "0.9.21"
 skillratings = "0.22.0"
 sqlx = { version = "0.6.2", features = ["postgres", "sqlite", "runtime-async-std-rustls", "time"] }
 tide = "0.16.0"

--- a/bughouse_console/example-test-config.yaml
+++ b/bughouse_console/example-test-config.yaml
@@ -1,0 +1,9 @@
+database_options: !Sqlite bughouse.db
+secret_database_options: !Sqlite bughouse-private.db
+auth_options: !Google
+  callback_is_https: false
+  client_id_source: !EnvVar GOOGLE_CLIENT_ID
+  client_secret_source: !EnvVar GOOGLE_CLIENT_SECRET
+session_options: WithNewRandomSecret
+static_content_url_prefix: http://localhost:8080
+allowed_origin: Any

--- a/bughouse_console/src/async_server_main.rs
+++ b/bughouse_console/src/async_server_main.rs
@@ -138,9 +138,14 @@ fn run_tide<DB: Sync + Send + 'static + DatabaseReader>(
 ) {
     let (google_auth, auth_callback_is_https) = match config.auth_options {
         AuthOptions::NoAuth => (None, false),
-        AuthOptions::GoogleAuthFromEnv { callback_is_https } => {
-            (Some(auth::GoogleAuth::new().unwrap()), callback_is_https)
-        }
+        AuthOptions::Google {
+            callback_is_https,
+            client_id_source,
+            client_secret_source,
+        } => (
+            Some(auth::GoogleAuth::new(client_id_source, client_secret_source).unwrap()),
+            callback_is_https,
+        ),
     };
     let mut app = tide::with_state(Arc::new(HttpServerStateImpl {
         sessions_enabled: config.session_options != SessionOptions::NoSessions,

--- a/bughouse_console/src/auth.rs
+++ b/bughouse_console/src/auth.rs
@@ -14,6 +14,7 @@ use oauth2::{
 use serde::Deserialize;
 use url::Url;
 
+use crate::server_config::StringSource;
 
 // Hash password to PHC string ($argon2id$v=19$...). It incorporates the salt too.
 pub fn hash_password(password: &str) -> anyhow::Result<String> {
@@ -61,16 +62,12 @@ impl NewSessionQuery {
 }
 
 impl GoogleAuth {
-    pub fn new() -> anyhow::Result<Self> {
+    pub fn new(client_id_source: StringSource,
+               client_secret_source: StringSource) -> anyhow::Result<Self> {
         // See https://accounts.google.com/.well-known/openid-configuration
-        let google_client_id = ClientId::new(
-            env::var("GOOGLE_CLIENT_ID")
-                .context("Missing the GOOGLE_CLIENT_ID environment variable.")?,
-        );
-        let google_client_secret = ClientSecret::new(
-            env::var("GOOGLE_CLIENT_SECRET")
-                .context("Missing the GOOGLE_CLIENT_SECRET environment variable.")?,
-        );
+        let google_client_id = ClientId::new(client_id_source.get()?);
+        let google_client_secret = ClientSecret::new(client_secret_source.get()?);
+
         let auth_url = AuthUrl::new("https://accounts.google.com/o/oauth2/v2/auth".to_owned())
             .context("Invalid authorization endpoint URL")?;
         let token_url = TokenUrl::new("https://oauth2.googleapis.com/token".to_owned())

--- a/bughouse_console/src/server_config.rs
+++ b/bughouse_console/src/server_config.rs
@@ -1,17 +1,43 @@
-#[derive(Debug, Clone)]
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum DatabaseOptions {
     NoDatabase,
     Sqlite(String),
     Postgres(String),
 }
 
-#[derive(Debug, Eq, PartialEq)]
-pub enum AuthOptions {
-    NoAuth,
-    GoogleAuthFromEnv { callback_is_https: bool },
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum StringSource {
+    EnvVar(String),
+    File(String),
 }
 
-#[derive(Debug, Eq, PartialEq)]
+impl StringSource {
+    pub fn get(&self) -> anyhow::Result<String> {
+        match self {
+            Self::EnvVar(v) => {
+                std::env::var(v).context(format!("Missing environment variable '{v}'."))
+            }
+            Self::File(f) => {
+                std::fs::read_to_string(f).context(format!("Failed to read file '{f}'."))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum AuthOptions {
+    NoAuth,
+    Google {
+        callback_is_https: bool,
+        client_id_source: StringSource,
+        client_secret_source: StringSource,
+    },
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SessionOptions {
     NoSessions,
 
@@ -24,13 +50,13 @@ pub enum SessionOptions {
     WithSecret(Vec<u8>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum AllowedOrigin {
     Any,
     ThisSite(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ServerConfig {
     pub database_options: DatabaseOptions,
     pub secret_database_options: DatabaseOptions,


### PR DESCRIPTION
The server CLI should be backwards-compatible but now it's possible to specify all the options in a config file.