### PR TITLE
Do not spawn an OS thread per connection.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,6 +594,7 @@ dependencies = [
 name = "bughouse_chess"
 version = "0.1.0"
 dependencies = [
+ "async-std",
  "chain-cmp",
  "chrono",
  "derive-new",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +393,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
+ "async-attributes",
  "async-channel",
  "async-global-executor",
  "async-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2021"
 strict = []  # treat warnings as a build error
 
 [dependencies]
+async-std = "1.12.0"
 chain-cmp = "0.2.0"
 # We don't use `chrono` ourselves, but some dependencies do. Until recently `chrono` depended
 # on `time 0.1.45`, which is affected by https://rustsec.org/advisories/RUSTSEC-2020-0071.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ time = { version = "0.3.29", features = ["formatting", "macros", "serde", "wasm-
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"
+async-std = { version = "1.12.0", features = ["attributes"] }

--- a/bughouse_console/src/server_main.rs
+++ b/bughouse_console/src/server_main.rs
@@ -44,7 +44,7 @@ async fn handle_connection<
     let (mut stream_tx, mut stream_rx) = stream.split();
     info!("Client connected: {}", peer_addr);
 
-    let (client_tx, client_rx) = mpsc::channel();
+    let (client_tx, client_rx) = async_std::channel::unbounded();
 
     let session_store_subscription_id = session_id.as_ref().map(|session_id| {
         // Subscribe the client to all updates to the session in session store.
@@ -101,31 +101,18 @@ async fn handle_connection<
         }
     });
 
-    // Still spawning an OS thread here because client_rx is a
-    // synchronous receiver.
-    // Calling blocking functions (such as client_rx.recv()) within async context
-    // means completely blocking an executor thread, which quickly leads to
-    // stavation and deadlocks because the number of async executor threads
-    // is limited.
-    let (done_tx, done_rx) = async_std::channel::bounded(1);
-    std::thread::spawn(move || {
-        loop {
-            let Ok(ev) = client_rx.recv() else { break };
-            match async_std::task::block_on(network::write_obj_async(&mut stream_tx, &ev)) {
-                Ok(()) => {}
-                Err(err) => {
-                    if let Some(logging_id) = remove_client2() {
-                        warn!("Client {} disconnected due to write error: {:?}", logging_id, err);
-                    }
-                    break;
+    loop {
+        let Ok(ev) = client_rx.recv().await else { break };
+        match network::write_obj_async(&mut stream_tx, &ev).await {
+            Ok(()) => {}
+            Err(err) => {
+                if let Some(logging_id) = remove_client2() {
+                    warn!("Client {} disconnected due to write error: {:?}", logging_id, err);
                 }
+                break;
             }
         }
-        async_std::task::block_on(done_tx.send(())).unwrap();
-    });
-    // This instead of just running the loop to completion or join() on the
-    // thread for the same reason of not blocking the async executor thread.
-    done_rx.recv().await.unwrap();
+    }
     Ok(())
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -209,7 +209,7 @@ pub struct ClientId(usize);
 
 #[derive(Debug)]
 pub struct Client {
-    events_tx: mpsc::Sender<BughouseServerEvent>,
+    events_tx: async_std::channel::Sender<BughouseServerEvent>,
     new_client: bool,
     match_id: Option<MatchId>,
     participant_id: Option<ParticipantId>,
@@ -219,7 +219,7 @@ pub struct Client {
 }
 
 impl Client {
-    fn send(&mut self, event: BughouseServerEvent) { self.events_tx.send(event).unwrap(); }
+    fn send(&mut self, event: BughouseServerEvent) { self.events_tx.try_send(event).unwrap(); }
     fn send_rejection(&mut self, rejection: BughouseServerRejection) {
         self.send(BughouseServerEvent::Rejection(rejection));
     }
@@ -235,8 +235,8 @@ impl Clients {
     pub fn new() -> Self { Clients { map: HashMap::new(), next_id: 1 } }
 
     pub fn add_client(
-        &mut self, events_tx: mpsc::Sender<BughouseServerEvent>, session_id: Option<SessionId>,
-        logging_id: String,
+        &mut self, events_tx: async_std::channel::Sender<BughouseServerEvent>,
+        session_id: Option<SessionId>, logging_id: String,
     ) -> ClientId {
         let now = Instant::now();
         let client = Client {

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,7 @@
 //   with a direct mapping (participant_id -> player_bughouse_id).
 
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::{mpsc, Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 use std::{iter, mem, ops};
 


### PR DESCRIPTION
Using `try_send` on the `unbounded` `async_std::channel::Sender`
bridges the synchronous code inside `server.rs` and asynchronous code
in main.

The price is, for now, the dependency of `server.rs` on `async_std`,
which can be eliminated with generics or dynamic sender object/fn
but I think it's not worth it.