### PR TITLE
Scale rating to look like Elo. Slow down rating updates for slightly better prediction.

### DIFF
--- a/bughouse_console/src/game_stats.rs
+++ b/bughouse_console/src/game_stats.rs
@@ -116,12 +116,7 @@ fn elo_config() -> EloConfig { EloConfig { k: 10.0 } }
 
 fn default_weng_lin() -> WengLinRating { WengLinRating { rating: 1600., uncertainty: 60.2 } }
 
-fn weng_lin_config() -> WengLinConfig {
-    WengLinConfig {
-        beta: 120.4,
-        ..Default::default()
-    }
-}
+fn weng_lin_config() -> WengLinConfig { WengLinConfig { beta: 120.4, ..Default::default() } }
 
 fn process_game(
     result: &str, prior_stats: GameStats, game_end_time: Option<OffsetDateTime>,
@@ -143,8 +138,12 @@ fn process_game(
 
     let prior_red_team_rating = prior_stats.red_team.rating.unwrap_or_else(default_weng_lin);
     let prior_blue_team_rating = prior_stats.blue_team.rating.unwrap_or_else(default_weng_lin);
-    let (red_team_rating, blue_team_rating) =
-        weng_lin(&prior_red_team_rating, &prior_blue_team_rating, &red_outcome, &weng_lin_config());
+    let (red_team_rating, blue_team_rating) = weng_lin(
+        &prior_red_team_rating,
+        &prior_blue_team_rating,
+        &red_outcome,
+        &weng_lin_config(),
+    );
 
     let prior_red_players_ratings =
         prior_stats.red_players.map(|p| p.rating.unwrap_or_else(default_weng_lin));


### PR DESCRIPTION
The `K` parameter for the Elo rating changed from `20` to `10`, meaning that we change the rating slower. This value showed the best mean square error out of the experiments I did (which were on integers around 10-20).

The Weng-Lin `beta/sigma` parameter (which is the only thing that affects the prediction quality of this system) was bumped from the default `0.5` to `2.0`, meaning that the rating changes slower as well. My interpretation of this is that the game is not skill-dependent enough to use the outcome of a single game to change the player's predicted strength much, matching [this definition](https://docs.rs/skillratings/latest/skillratings/weng_lin/struct.WengLinConfig.html#structfield.beta) for `beta`.

The Weng-Lin parameters are scaled to mimic Elo with initial rating of `1600` and `120.4` difference corresponding to score prediction of `2/3`. The `beta` parameter was set according to that "skill-class gap", and then sigma was tuned to give the optimal result. There is a range of parameters that work almost equally well, the largest "round" number (`0.5 * beta`) was picked, so that new player's rating change as quickly as possible without sacrificing prediction quality.

Mean square error of score prediction after `1847` rated games follows. All of the rating systems improved, by a small amount (except `team_pointrate` which obviously shouldn't and didn't changed):

| Rating system | Old Loss  | New Loss  |
|----------------------|---------------|--------------|
| team_elo      | 0.235102  | 0.2337209  |
| player_rating | 0.2356257 | 0.2338486 |
| team_rating   | 0.2377491 | 0.2334674 |
| team_pointrate| 0.2390422 | 0.2390422 |

`team_rating` is now the best predictor, while `player_rating` is about as good as `team_elo`, and `team_pointrate` remains the worst.

The overall shapes of the rating graphs are similar but there's noticeably less spikes in the beginning of each player's career.
![2024-04-20_01-17](https://github.com/amatveiakin/bughouse-chess/assets/5024136/8bca1863-8fa7-476d-aa1b-728b5ce37077)
![2024-04-20_01-06](https://github.com/amatveiakin/bughouse-chess/assets/5024136/59fb6163-68d1-45e6-b95b-a4f774900024)

